### PR TITLE
Propagate error in the Left method

### DIFF
--- a/speedbump.go
+++ b/speedbump.go
@@ -83,7 +83,7 @@ func (r *RateLimiter) Left(id string) (int64, error) {
 	attempted, err := r.Attempted(id)
 
 	if err != nil {
-		return 0, nil
+		return 0, err
 	}
 
 	left := r.max - attempted


### PR DESCRIPTION
For some reasons, the error was not propagated here. It seems like a small mistake, as you don't want to silently dismiss a possible error in `Attempted `