### PR TITLE
[experimental] speedbump without dependency on redis.v5

### DIFF
--- a/contrib/github.com/go-redis/redis.v5/redis.go
+++ b/contrib/github.com/go-redis/redis.v5/redis.go
@@ -1,0 +1,44 @@
+package redis
+
+import (
+	"time"
+
+	"github.com/ntindall/speedbump/internal"
+	redis "gopkg.in/redis.v5"
+)
+
+// Wrapper is a wrapper around *redis.Client that implements the
+// internal.RedisClient interface.
+type Wrapper struct {
+	*redis.Client
+}
+
+var _ internal.RedisClient = &Wrapper{}
+
+func (w *Wrapper) Exists(key string) (exists bool, err error) {
+	return w.Client.Exists(key).Result()
+}
+
+func (w *Wrapper) Get(key string) (value string, err error) {
+	return w.Client.Get(key).Result()
+}
+
+func (w *Wrapper) IncrAndExpire(key string, duration time.Duration) error {
+	return w.Client.Watch(func(rx *redis.Tx) error {
+		_, err := rx.Pipelined(func(pipe *redis.Pipeline) error {
+			if err := pipe.Incr(key).Err(); err != nil {
+				return err
+			}
+
+			return pipe.Expire(key, duration).Err()
+		})
+
+		return err
+	})
+}
+
+// NewRedisClient constructs a speedbump.RedisClient from a "gopkg.in/redis.v5"
+// redis.Client.
+func NewRedisClient(redisClient *redis.Client) internal.RedisClient {
+	return &Wrapper{redisClient}
+}

--- a/contrib/github.com/gomodule/redigo/redis/redis.go
+++ b/contrib/github.com/gomodule/redigo/redis/redis.go
@@ -1,0 +1,41 @@
+package redis
+
+import (
+	"time"
+
+	redis "github.com/gomodule/redigo/redis"
+	"github.com/ntindall/speedbump/internal"
+)
+
+type redisWrapper struct {
+	conn redis.Conn
+}
+
+var _ internal.RedisClient = &redisWrapper{}
+
+func (w *redisWrapper) Exists(key string) (exists bool, err error) {
+	return redis.Bool(w.conn.Do("EXISTS", key))
+}
+
+func (w *redisWrapper) Get(key string) (value string, err error) {
+	return redis.String(w.conn.Do("GET", key))
+}
+
+func (w *redisWrapper) IncrAndExpire(key string, duration time.Duration) error {
+	if err := w.conn.Send("MULTI"); err != nil {
+		return err
+	}
+	if err := w.conn.Send("INCR", key); err != nil {
+		return err
+	}
+	if err := w.conn.Send("EXPIRE", key, duration/time.Second); err != nil {
+		return err
+	}
+	_, err := w.conn.Do("EXEC")
+	return err
+}
+
+// NewRedisClient constructs a internal.RedisClient from a redigo connection.
+func NewRedisClient(redisConn redis.Conn) internal.RedisClient {
+	return &redisWrapper{conn: redisConn}
+}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,0 +1,14 @@
+package internal
+
+import (
+	"time"
+)
+
+// RedisClient is an abstraction over speedbump connection to redis.
+// It is exported from internal so that it can only be instructed from
+// within the package.
+type RedisClient interface {
+	Get(key string) (value string, err error)
+	Exists(key string) (exists bool, err error)
+	IncrAndExpire(key string, duration time.Duration) error
+}


### PR DESCRIPTION
Removes dependency on `redis.v5` from the core speedbump logic. Clients can use `contrib` constructors to construct rate limiters using different redis implementations.

Since the need for pipelining and simultaneous increment/expiration, I made the interface internal so that it cannot be implemented by clients (although it can be _used_)... RFC on this.